### PR TITLE
Revert to using readline 6.2.  

### DIFF
--- a/src/readline.cfg
+++ b/src/readline.cfg
@@ -9,7 +9,7 @@ dummy-readline = ${readline:recipe}
 
 [readline:default]
 recipe = collective.recipe.cmmi
-url = https://ftp.gnu.org/gnu/readline/readline-6.3.tar.gz
+url = https://ftp.gnu.org/gnu/readline/readline-6.2.tar.gz
 extra_options =
     --prefix=${opt:location}
 

--- a/src/test-python.py
+++ b/src/test-python.py
@@ -14,3 +14,8 @@ def test(options, buildout):
         output = Popen([python, "-c", "import socket; print (hasattr(socket, 'ssl'))"], stdout=PIPE).communicate()[0]
         if not output.startswith("True"):
             raise IOError("Your python at %s doesn't have ssl support, got: %s" % (python, output))
+
+    output = Popen([python, "-c", "import readline; print (readline)"], stdout=PIPE).communicate()[0]
+    # The leading escape sequence is sometimes printed by readline on import (see https://bugs.python.org/msg191824)
+    if not output.lstrip("\x1b[?1034h").startswith("<module"):
+        raise IOError("Your python at %s doesn't have readline support, got: %s" % (python,output))


### PR DESCRIPTION
Without this, the readline extension silently fails to build in Python 2.4.
